### PR TITLE
open and read the README as utf-8

### DIFF
--- a/skeleton/skeleton.asd
+++ b/skeleton/skeleton.asd
@@ -39,6 +39,7 @@
                              #p"README.markdown"
                              (or *load-pathname* *compile-file-pathname*))
                             :if-does-not-exist nil
+                            :external-format :utf-8
                             :direction :input)
       (when stream
         (let ((seq (make-array (file-length stream)


### PR DESCRIPTION
so than we can write non-ascii characters in the README and load the .asd without errors.